### PR TITLE
Warning after fresh install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
         "zendframework/zend-view": "~2.4.0",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-apigility-documentation": "~1.0",
-        "zfcampus/zf-content-negotiation": "~1.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "zfcampus/zf-content-negotiation": "~1.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "3.7.*"
+        "phpunit/phpunit": "~4.7",
+        "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -99,7 +99,7 @@ class Resource
      */
     public function getBodyProperties()
     {
-        return $this->service->getFields();
+        return $this->service->getFields('input_filter');
     }
 
     /**

--- a/test/ResourceTest.php
+++ b/test/ResourceTest.php
@@ -23,6 +23,8 @@ class ResourceTest extends TestCase
             ->expects($this->any())
             ->method('getRouteIdentifierName')
             ->will($this->returnValue('Mock parameter'));
+
+        $this->service  = $baseServiceMock;
         $this->resource = new Resource($baseServiceMock, array(), 'blueprint/test', 'entity');
     }
 
@@ -34,5 +36,19 @@ class ResourceTest extends TestCase
     public function testResourceParameter()
     {
         $this->assertEquals($this->resource->getParameter(), 'Mock parameter');
+    }
+
+    /**
+     * @group 4
+     */
+    public function testPullsFieldsWhenRetrievingBodyProperties()
+    {
+        $this->service
+            ->expects($this->once())
+            ->method('getFields')
+            ->with($this->equalTo('input_filter'))
+            ->willReturn(array());
+
+        $this->resource->getBodyProperties();
     }
 }


### PR DESCRIPTION
I installed fresh instance of Apigility na this module. I did a request to `/apigility/blueprint/MyApi` with and I received correct api blueprint response but with php warning on the beginning:

```
Warning: Missing argument 1 for ZF\Apigility\Documentation\Service::getFields(), called in /home/witold/www/apigility/vendor/zfcampus/zf-apigility-documentation-apiblueprint/src/Resource.php on line 102 and defined in /home/witold/www/apigility/vendor/zfcampus/zf-apigility-documentation/src/Service.php on line 240
```